### PR TITLE
Support for Monash's MASSIVE M3 cluster (slurm scheduler)

### DIFF
--- a/nispat/fileio.py
+++ b/nispat/fileio.py
@@ -313,7 +313,8 @@ def save_pd(data, filename):
     data.to_csv(filename,
                 index=None,
                 header=None,
-                sep=' ')
+                sep=' ',
+                na_rep='NaN')
 
 
 def load_ascii(filename):

--- a/nispat/normative_parallel.py
+++ b/nispat/normative_parallel.py
@@ -70,6 +70,7 @@ def execute_nm(processing_dir,
                batch_size,
                memory,
                duration,
+               cluster_spec,
                cv_folds=None,
                testcovfile_path=None,
                testrespfile_path=None,
@@ -114,9 +115,9 @@ def execute_nm(processing_dir,
     split_nm(processing_dir, respfile_path, batch_size, testrespfile_path)
 
     batch_dir = glob.glob(processing_dir + 'batch_*')
-    print(batch_dir)
+    # print(batch_dir)
     number_of_batches = len(batch_dir)
-    print(number_of_batches)
+    # print(number_of_batches)
 
     for n in range(1, number_of_batches+1):
         print(n)
@@ -126,6 +127,7 @@ def execute_nm(processing_dir,
                 raise(ValueError, """If the response file is specified
                                      cv_folds must be equal to None""")
             else:
+                # specified train/test split
                 batch_processing_dir = processing_dir + 'batch_' + str(n) + '/'
                 batch_job_name = job_name + str(n) + '.sh'
                 batch_respfile_path = (batch_processing_dir + 'resp_batch_' +
@@ -134,41 +136,72 @@ def execute_nm(processing_dir,
                                            'testresp_batch_' + str(n) + '.txt')
                 batch_job_path = batch_processing_dir + batch_job_name
 
-                bashwrap_nm(processing_dir=batch_processing_dir,
-                            python_path=python_path,
-                            normative_path=normative_path,
-                            job_name=batch_job_name,
-                            covfile_path=covfile_path,
-                            cv_folds=cv_folds,
-                            respfile_path=batch_respfile_path,
-                            testcovfile_path=testcovfile_path,
-                            testrespfile_path=batch_testrespfile_path,
-                            bash_environment=bash_environment)
-                qsub_nm(job_path=batch_job_path,
-                        memory=memory,
-                        duration=duration)
+                if cluster_spec is 'torque':
+                    bashwrap_nm(processing_dir=batch_processing_dir,
+                                python_path=python_path,
+                                normative_path=normative_path,
+                                job_name=batch_job_name,
+                                covfile_path=covfile_path,
+                                cv_folds=cv_folds,
+                                respfile_path=batch_respfile_path,
+                                testcovfile_path=testcovfile_path,
+                                testrespfile_path=batch_testrespfile_path,
+                                bash_environment=bash_environment)
+                    qsub_nm(job_path=batch_job_path,
+                            memory=memory,
+                            duration=duration)
+                elif cluster_spec is 'm3':
+                    bashwrap_nm_m3(processing_dir=batch_processing_dir,
+                                python_path=python_path,
+                                normative_path=normative_path,
+                                job_name=batch_job_name,
+                                covfile_path=covfile_path,
+                                respfile_path=batch_respfile_path,
+                                duration=duration,
+                                memory=memory,
+                                cv_folds=cv_folds,
+                                testcovfile_path=testcovfile_path,
+                                testrespfile_path=batch_testrespfile_path)
+                    sbatch_nm(job_path=batch_job_path)
 
         if testrespfile_path is None:
             if testcovfile_path is not None:
+                # forward model
                 batch_processing_dir = processing_dir + 'batch_' + str(n) + '/'
                 batch_job_name = job_name + str(n) + '.sh'
                 batch_respfile_path = (batch_processing_dir + 'resp_batch_' +
                                        str(n) + '.txt')
                 batch_job_path = batch_processing_dir + batch_job_name
 
-                bashwrap_nm(processing_dir=batch_processing_dir,
-                            python_path=python_path,
-                            normative_path=normative_path,
-                            job_name=batch_job_name,
-                            covfile_path=covfile_path,
-                            cv_folds=cv_folds,
-                            respfile_path=batch_respfile_path,
-                            testcovfile_path=testcovfile_path,
-                            bash_environment=bash_environment)
-                qsub_nm(job_path=batch_job_path,
-                        memory=memory,
-                        duration=duration)
+                if cluster_spec is 'torque':
+                    bashwrap_nm(processing_dir=batch_processing_dir,
+                                python_path=python_path,
+                                normative_path=normative_path,
+                                job_name=batch_job_name,
+                                covfile_path=covfile_path,
+                                cv_folds=cv_folds,
+                                respfile_path=batch_respfile_path,
+                                testcovfile_path=testcovfile_path,
+                                bash_environment=bash_environment)
+                    qsub_nm(job_path=batch_job_path,
+                            memory=memory,
+                            duration=duration)
+                elif cluster_spec is 'm3':
+                    bashwrap_nm_m3(processing_dir=batch_processing_dir,
+                                python_path=python_path,
+                                normative_path=normative_path,
+                                job_name=batch_job_name,
+                                covfile_path=covfile_path,
+                                respfile_path=batch_respfile_path,
+                                duration=duration,
+                                memory=memory,
+                                cv_folds=cv_folds,
+                                testcovfile_path=testcovfile_path)
+                    sbatch_nm(job_path=batch_job_path)
+
+
             else:
+                # cross-val?
                 batch_processing_dir = (processing_dir + 'batch_' +
                                         str(n) + '/')
                 batch_job_name = job_name + str(n) + '.sh'
@@ -176,19 +209,33 @@ def execute_nm(processing_dir,
                                        'resp_batch_' + str(n) + '.txt')
                 batch_job_path = batch_processing_dir + batch_job_name
 
-                bashwrap_nm(processing_dir=batch_processing_dir,
-                            python_path=python_path,
-                            normative_path=normative_path,
-                            job_name=batch_job_name,
-                            covfile_path=covfile_path,
-                            cv_folds=cv_folds,
-                            respfile_path=batch_respfile_path,
-                            testcovfile_path=testcovfile_path,
-                            testrespfile_path=testrespfile_path,
-                            bash_environment=bash_environment)
-                qsub_nm(job_path=batch_job_path,
-                        memory=memory,
-                        duration=duration)
+                if cluster_spec is 'torque':
+                    bashwrap_nm(processing_dir=batch_processing_dir,
+                                python_path=python_path,
+                                normative_path=normative_path,
+                                job_name=batch_job_name,
+                                covfile_path=covfile_path,
+                                cv_folds=cv_folds,
+                                respfile_path=batch_respfile_path,
+                                testcovfile_path=testcovfile_path,
+                                testrespfile_path=testrespfile_path,
+                                bash_environment=bash_environment)
+                    qsub_nm(job_path=batch_job_path,
+                            memory=memory,
+                            duration=duration)
+                elif cluster_spec is 'm3':
+                    bashwrap_nm_m3(processing_dir=batch_processing_dir,
+                                python_path=python_path,
+                                normative_path=normative_path,
+                                job_name=batch_job_name,
+                                covfile_path=covfile_path,
+                                respfile_path=batch_respfile_path,
+                                memory=memory,
+                                duration=duration,
+                                cv_folds=cv_folds,
+                                testcovfile_path=testcovfile_path,
+                                testrespfile_path=testrespfile_path)
+                    sbatch_nm(job_path=batch_job_path)
 
 
 def split_nm(processing_dir, respfile_path, batch_size,
@@ -398,6 +445,119 @@ def qsub_nm(job_path, memory, duration):
 
     # submits job to cluster
     call(qsub_call, shell=True)
+
+
+def bashwrap_nm_m3(processing_dir, python_path, normative_path, job_name,
+                covfile_path, respfile_path, duration, memory,
+                cv_folds=None, testcovfile_path=None,
+                testrespfile_path=None):
+
+    """ This function wraps normative modelling into a bash script to run it
+    on the MASSIVE M3 cluster at Monash University, Melbourne, Australia.
+
+    ** Input:
+        * processing_dir     -> Full path to the processing dir
+        * python_path        -> Full path to the python distribution
+        * normative_path     -> Full path to the normative.py
+        * job_name           -> Name for the bash script that is the output of
+                                this function
+        * covfile_path       -> Full path to a .txt file that contains all
+                                covariats (subjects x covariates) for the
+                                responsefile
+        * respfile_path      -> Full path to a .txt that contains all features
+                                (subjects x features)
+        * cv_folds           -> Number of cross validations
+        * testcovfile_path   -> Full path to a .txt file that contains all
+                                covariats (subjects x covariates) for the
+                                testresponse file
+        * testrespfile_path  -> Full path to a .txt file that contains all
+                                test features
+
+    ** Output:
+        * A bash.sh file containing the commands for normative modelling saved
+        to the processing directory
+
+    Original code written by Thomas Wolfers. Adapted by Linden Parkes.
+    """
+
+    # import of necessary modules
+    import os
+
+    # change to processing dir
+    os.chdir(processing_dir)
+    output_changedir = ['cd ' + processing_dir + '\n']
+
+    # sets bash environment if necessary
+    bash_lines = '#!/bin/bash\n'
+    bash_sbatch = '#SBATCH --job-name=' + job_name + ' \n#SBATCH --account=kg98 \n#SBATCH --ntasks=1 \n#SBATCH --cpus-per-task=1 \n#SBATCH --time=' + duration + ' \n#SBATCH --mem-per-cpu=' + memory + ' \n'
+    bash_m3node = 'echo "Running on `hostname` at `date`"\n'
+    bash_cores = 'export OMP_NUM_THREADS=1\n'
+    bash_pysetup = 'source /home/lindenmp/virtual_env/py36_nm/bin/activate\nmodule load python/3.6.2\n'
+    bash_environment = [bash_lines + bash_sbatch + bash_m3node + bash_cores + bash_pysetup]
+
+    # creates call of function for normative modelling
+    if testrespfile_path is not None:
+        if testcovfile_path is not None:
+            if cv_folds is not None:
+                raise(ValueError, """If the testrespfile_path and
+                                  testcovfile_path are not specified
+                                  cv_folds must be equal to None""")
+            else:
+                job_call = [python_path + ' ' + normative_path + ' -c ' +
+                            covfile_path + ' -t ' + testcovfile_path + ' -r ' +
+                            testrespfile_path + ' ' + respfile_path]
+
+    if testrespfile_path is None:
+        if testcovfile_path is None:
+            if cv_folds is not None:
+                job_call = [python_path + ' ' + normative_path + ' -c ' +
+                            covfile_path + ' -k ' + str(cv_folds) + ' ' +
+                            respfile_path]
+            else:
+                raise(ValueError, """If the testresponsefile_path and
+                                  testcovfile_path are specified cv_folds
+                                  must be larger than or equal to two(2)""")
+
+    if testrespfile_path is None:
+        if testcovfile_path is not None:
+            if cv_folds is None:
+                job_call = [python_path + ' ' + normative_path + ' -c ' +
+                            covfile_path + ' -t ' + testcovfile_path + ' ' +
+                            respfile_path]
+            else:
+                raise(ValueError, """If the test response file is and
+                                  testcovfile is not specified cv_folds
+                                  must be NONE""")
+
+    # writes bash file into processing dir
+    with open(processing_dir + job_name, 'w') as bash_file:
+        bash_file.writelines(bash_environment + output_changedir + job_call + [" | ts \n"])
+
+    # changes permissoins for bash.sh file
+    os.chmod(processing_dir + job_name, 0o700)
+
+def sbatch_nm(job_path):
+    """
+    This function submits a job.sh scipt to the MASSIVE M3 cluster at Monash University, Melbourne, Australia, using the sbatch
+    command.
+
+    ** Input:
+        * job_path      -> Full path to the job.sh file
+
+    ** Output:
+        * Submission of the job to the cluster
+
+    Original code written by Thomas Wolfers. Adapted by Linden Parkes.
+    """
+
+    # import of necessary modules
+    from subprocess import call
+
+    # created qsub command
+    sbatch_call = ['sbatch ' + job_path]
+
+    # submits job to cluster
+    call(sbatch_call, shell=True)
 
 
 def collect_nm(processing_dir, collect=False):
@@ -656,6 +816,27 @@ def rerun_nm(processing_dir, memory, duration):
         nispat.normative_parallel.qsub_nm(job_path=jobpath,
                                           memory=memory,
                                           duration=duration)
+
+
+def rerun_nm_m3(processing_dir):
+    """This function reruns all failed batched in processing_dir after collect_nm
+    has identified he failed batches
+
+    * Input:
+        * processing_dir        -> Full path to the processing directory
+
+
+    written by Thomas Wolfers. Adapted by Linden Parkes.
+    """
+    import nispat
+
+    failed_batches = nispat.fileio.load_pd(processing_dir +
+                                           'failed_batches.txt')
+    shape = failed_batches.shape
+    for n in range(0, shape[0]):
+        jobpath = failed_batches.iloc[n, 0]
+        print(jobpath)
+        nispat.normative_parallel.sbatch_nm(job_path=jobpath)
 
 
 def delete_nm(processing_dir):


### PR DESCRIPTION
Changes:
1) normative_parallel.py. Added new routines to wrap and submit normative batches to a slurm scheduler.
2) normative.py. Small change to have failed voxels written as NaN. This just prevents entire batches failing when a single voxel fails.
3) fileio.py. Small change to handle NaNs in output caused by 2)